### PR TITLE
Upgrade Clojurescript for JDK 9 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ language: clojure
 jdk:
   - openjdk8
   - oraclejdk8
+  - oraclejdk9
 lein: 2.8.1
 before_install:
-- sudo add-apt-repository -y ppa:mfikes/planck
-- sudo apt-get update -qq
-- sudo apt-get install -qq planck
+  - sudo add-apt-repository -y ppa:mfikes/planck
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq planck
 script: lein all-tests

--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
   :profiles
   {:dev
    {:dependencies [[org.clojure/clojure "1.9.0"]
-                   [org.clojure/clojurescript "1.9.946"]]}}
+                   [org.clojure/clojurescript "1.10.238"]]}}
 
   :source-paths ["src"]
   :test-paths ["test/cljc"]


### PR DESCRIPTION
* Upgrade Clojurescript for JDK 9 support
* Add JDK 9 to Travis

Fixes : #10 